### PR TITLE
feat: add workflow to sync repo with wiki

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,23 @@
+name: Sync to Wiki
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  sync:
+    name: Sync to Wiki
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set git config
+        run: |
+          git config --global user.email ${{ secrets.GIT_EMAIL }}
+          git config --global user.name ${{ secrets.GIT_USERNAME }}
+      - name: Add remote wiki path
+        run: git remote add wiki https://${{ github.token }}@github.com/${{ github.repository }}.wiki
+      - name: Push changes to remote wiki
+        run: git push wiki master -f


### PR DESCRIPTION
Pelo que entendi a wiki funciona como se fosse um outro repositório, então a ideia foi criar uma action para toda vez que for feito um push na branch master, ele pega todo o conteúdo da master e joga pro repo referente a wiki (atualizando assim seu conteudo).

Vi que tinham algumas actions custom de uma galera fazendo isso, porém optei por fazer o processo manual no arquivo de workflow para a gnt ter mais flexibilidade caso precise mudar alguma coisa.

O processo se baseia basicamente em: 
- subir uma máquina ubuntu
- setar um usuário e um email para configuração do git
- adicionar um remote referente ao link do repo da wiki
- dar um push da branch master do repo para a branch master da wiki

Para funcionar corretamente é necessário duas variáveis de ambiente/secrets configuradas no repositório:

GIT_EMAIL = email do usuário que ira realizar o push no repo da wiki
GIT_USERNAME = nome do usuário que ira realizar o push no repo da wiki

![image](https://user-images.githubusercontent.com/41276009/86495505-11176280-bd50-11ea-9c77-0df59cd1677f.png)

![image](https://user-images.githubusercontent.com/41276009/86495530-2ab8aa00-bd50-11ea-8d8e-9b4c128de981.png)


Closes #3